### PR TITLE
Platform constructors

### DIFF
--- a/src/main/java/com/nawforce/runforce/Schema/ChildRelationship.java
+++ b/src/main/java/com/nawforce/runforce/Schema/ChildRelationship.java
@@ -29,6 +29,8 @@ public class ChildRelationship {
 	public String RelationshipName;
 	public Boolean RestrictedDelete;
 
+    private ChildRelationship(){throw new java.lang.UnsupportedOperationException();}
+
 	public SObjectType getChildSObject() {throw new java.lang.UnsupportedOperationException();}
 	public SObjectField getField() {throw new java.lang.UnsupportedOperationException();}
 	public List<String> getJunctionIdListNames() {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/Schema/DataCategory.java
+++ b/src/main/java/com/nawforce/runforce/Schema/DataCategory.java
@@ -23,6 +23,8 @@ public class DataCategory {
 	public String Label;
 	public String Name;
 
+    private DataCategory(){throw new java.lang.UnsupportedOperationException();}
+
 	public List<DataCategory> getChildCategories() {throw new java.lang.UnsupportedOperationException();}
 	public String getLabel() {throw new java.lang.UnsupportedOperationException();}
 	public String getName() {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/Schema/DescribeColorResult.java
+++ b/src/main/java/com/nawforce/runforce/Schema/DescribeColorResult.java
@@ -22,6 +22,8 @@ public class DescribeColorResult {
 	public String Context;
 	public String Theme;
 
+    private DescribeColorResult(){throw new java.lang.UnsupportedOperationException();}
+
 	public String getColor() {throw new java.lang.UnsupportedOperationException();}
 	public String getContext() {throw new java.lang.UnsupportedOperationException();}
 	public String getTheme() {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/Schema/DescribeDataCategoryGroupResult.java
+++ b/src/main/java/com/nawforce/runforce/Schema/DescribeDataCategoryGroupResult.java
@@ -25,6 +25,8 @@ public class DescribeDataCategoryGroupResult {
 	public String Name;
 	public String Sobject;
 
+    private DescribeDataCategoryGroupResult(){throw new java.lang.UnsupportedOperationException();}
+
 	public Integer getCategoryCount() {throw new java.lang.UnsupportedOperationException();}
 	public String getDescription() {throw new java.lang.UnsupportedOperationException();}
 	public String getLabel() {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/Schema/DescribeDataCategoryGroupStructureResult.java
+++ b/src/main/java/com/nawforce/runforce/Schema/DescribeDataCategoryGroupStructureResult.java
@@ -25,6 +25,8 @@ public class DescribeDataCategoryGroupStructureResult {
 	public String Sobject;
 	public List<DataCategory> TopCategories;
 
+    private DescribeDataCategoryGroupStructureResult(){throw new java.lang.UnsupportedOperationException();}
+
 	public String getDescription() {throw new java.lang.UnsupportedOperationException();}
 	public String getLabel() {throw new java.lang.UnsupportedOperationException();}
 	public String getName() {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/Schema/DescribeFieldResult.java
+++ b/src/main/java/com/nawforce/runforce/Schema/DescribeFieldResult.java
@@ -80,6 +80,8 @@ public class DescribeFieldResult {
 	public Boolean Updateable;
 	public Boolean WriteRequiresMasterRead;
 
+    private DescribeFieldResult(){throw new java.lang.UnsupportedOperationException();}
+
 	public Integer getByteLength() {throw new java.lang.UnsupportedOperationException();}
 	public String getCalculatedFormula() {throw new java.lang.UnsupportedOperationException();}
 	public String getCompoundFieldName() {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/Schema/DescribeIconResult.java
+++ b/src/main/java/com/nawforce/runforce/Schema/DescribeIconResult.java
@@ -25,6 +25,8 @@ public class DescribeIconResult {
 	public String Url;
 	public Integer Width;
 
+    private DescribeIconResult(){throw new java.lang.UnsupportedOperationException();}
+
 	public String getContentType() {throw new java.lang.UnsupportedOperationException();}
 	public Integer getHeight() {throw new java.lang.UnsupportedOperationException();}
 	public String getTheme() {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/Schema/DescribeSObjectResult.java
+++ b/src/main/java/com/nawforce/runforce/Schema/DescribeSObjectResult.java
@@ -49,7 +49,7 @@ public class DescribeSObjectResult {
 	public Boolean Undeletable;
 	public Boolean Updateable;
 
-    private DescribeSObjectResult(){throw new java.lang.UnsupportedOperationException();}
+    protected DescribeSObjectResult(){throw new java.lang.UnsupportedOperationException();}
 
 	public List<ChildRelationship> getChildRelationships() {throw new java.lang.UnsupportedOperationException();}
 	public SObjectTypeFieldSets getFieldSets() {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/Schema/DescribeSObjectResult.java
+++ b/src/main/java/com/nawforce/runforce/Schema/DescribeSObjectResult.java
@@ -49,6 +49,8 @@ public class DescribeSObjectResult {
 	public Boolean Undeletable;
 	public Boolean Updateable;
 
+    private DescribeSObjectResult(){throw new java.lang.UnsupportedOperationException();}
+
 	public List<ChildRelationship> getChildRelationships() {throw new java.lang.UnsupportedOperationException();}
 	public SObjectTypeFieldSets getFieldSets() {throw new java.lang.UnsupportedOperationException();}
 	public SObjectTypeFields getFields() {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/Schema/DescribeTabResult.java
+++ b/src/main/java/com/nawforce/runforce/Schema/DescribeTabResult.java
@@ -31,6 +31,8 @@ public class DescribeTabResult {
 	public String TabEnumOrId;
 	public String Url;
 
+    private DescribeTabResult(){throw new java.lang.UnsupportedOperationException();}
+
 	public List<DescribeColorResult> getColors() {throw new java.lang.UnsupportedOperationException();}
 	public String getIconUrl() {throw new java.lang.UnsupportedOperationException();}
 	public List<DescribeIconResult> getIcons() {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/Schema/DescribeTabSetResult.java
+++ b/src/main/java/com/nawforce/runforce/Schema/DescribeTabSetResult.java
@@ -28,6 +28,8 @@ public class DescribeTabSetResult {
 	public List<DescribeTabResult> Tabs;
 	public String TabSetId;
 
+    private DescribeTabSetResult(){throw new java.lang.UnsupportedOperationException();}
+
 	public String getDescription() {throw new java.lang.UnsupportedOperationException();}
 	public String getLabel() {throw new java.lang.UnsupportedOperationException();}
 	public String getLogoUrl() {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/Schema/FieldSet.java
+++ b/src/main/java/com/nawforce/runforce/Schema/FieldSet.java
@@ -26,6 +26,8 @@ public class FieldSet {
 	public String NameSpace;
 	public SObjectType SObjectType;
 
+    private FieldSet(){throw new java.lang.UnsupportedOperationException();}
+
 	public String getDescription() {throw new java.lang.UnsupportedOperationException();}
 	public List<FieldSetMember> getFields() {throw new java.lang.UnsupportedOperationException();}
 	public String getLabel() {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/Schema/FieldSetMember.java
+++ b/src/main/java/com/nawforce/runforce/Schema/FieldSetMember.java
@@ -25,6 +25,8 @@ public class FieldSetMember {
 	public Boolean Required;
 	public DisplayType Type;
 
+    private FieldSetMember(){throw new java.lang.UnsupportedOperationException();}
+
 	public Boolean getDbRequired() {throw new java.lang.UnsupportedOperationException();}
 	public String getFieldPath() {throw new java.lang.UnsupportedOperationException();}
 	public String getLabel() {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/Schema/FilteredLookupInfo.java
+++ b/src/main/java/com/nawforce/runforce/Schema/FilteredLookupInfo.java
@@ -24,6 +24,8 @@ public class FilteredLookupInfo {
 	public Boolean Dependent;
 	public Boolean OptionalFilter;
 
+    private FilteredLookupInfo(){throw new java.lang.UnsupportedOperationException();}
+
 	public List<String> getControllingFields() {throw new java.lang.UnsupportedOperationException();}
 	public Boolean isDependent() {throw new java.lang.UnsupportedOperationException();}
 	public Boolean isOptionalFilter() {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/Schema/PicklistEntry.java
+++ b/src/main/java/com/nawforce/runforce/Schema/PicklistEntry.java
@@ -24,6 +24,8 @@ public class PicklistEntry {
 	public String Label;
 	public String Value;
 
+    private PicklistEntry(){throw new java.lang.UnsupportedOperationException();}
+
 	public String getLabel() {throw new java.lang.UnsupportedOperationException();}
 	public String getValue() {throw new java.lang.UnsupportedOperationException();}
 	public Boolean isActive() {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/Schema/RecordTypeInfo.java
+++ b/src/main/java/com/nawforce/runforce/Schema/RecordTypeInfo.java
@@ -28,6 +28,8 @@ public class RecordTypeInfo {
 	public String Name;
 	public Id RecordTypeId;
 
+    private RecordTypeInfo(){throw new java.lang.UnsupportedOperationException();}
+
 	public String getDeveloperName() {throw new java.lang.UnsupportedOperationException();}
 	public String getName() {throw new java.lang.UnsupportedOperationException();}
 	public Id getRecordTypeId() {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/Schema/SObjectField.java
+++ b/src/main/java/com/nawforce/runforce/Schema/SObjectField.java
@@ -16,6 +16,8 @@ package com.nawforce.runforce.Schema;
 
 @SuppressWarnings("unused")
 public class SObjectField {
+    private SObjectField(){throw new java.lang.UnsupportedOperationException();}
+
 	public DescribeFieldResult getDescribe() {throw new java.lang.UnsupportedOperationException();}
 	public DescribeFieldResult getDescribe(Object options) {throw new java.lang.UnsupportedOperationException();}
 }

--- a/src/main/java/com/nawforce/runforce/Schema/SObjectField.java
+++ b/src/main/java/com/nawforce/runforce/Schema/SObjectField.java
@@ -16,7 +16,7 @@ package com.nawforce.runforce.Schema;
 
 @SuppressWarnings("unused")
 public class SObjectField {
-    private SObjectField(){throw new java.lang.UnsupportedOperationException();}
+    protected SObjectField(){throw new java.lang.UnsupportedOperationException();}
 
 	public DescribeFieldResult getDescribe() {throw new java.lang.UnsupportedOperationException();}
 	public DescribeFieldResult getDescribe(Object options) {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/Schema/SObjectType.java
+++ b/src/main/java/com/nawforce/runforce/Schema/SObjectType.java
@@ -20,6 +20,8 @@ import com.nawforce.runforce.System.SObject;
 
 @SuppressWarnings("unused")
 public class SObjectType {
+    private SObjectType(){throw new java.lang.UnsupportedOperationException();}
+
 	public DescribeSObjectResult getDescribe() {throw new java.lang.UnsupportedOperationException();}
 	public DescribeSObjectResult getDescribe(Object options) {throw new java.lang.UnsupportedOperationException();}
 	public SObject newSObject() {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/Schema/SObjectType.java
+++ b/src/main/java/com/nawforce/runforce/Schema/SObjectType.java
@@ -20,7 +20,7 @@ import com.nawforce.runforce.System.SObject;
 
 @SuppressWarnings("unused")
 public class SObjectType {
-    private SObjectType(){throw new java.lang.UnsupportedOperationException();}
+    protected SObjectType(){throw new java.lang.UnsupportedOperationException();}
 
 	public DescribeSObjectResult getDescribe() {throw new java.lang.UnsupportedOperationException();}
 	public DescribeSObjectResult getDescribe(Object options) {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/Schema/SObjectTypeFieldSets.java
+++ b/src/main/java/com/nawforce/runforce/Schema/SObjectTypeFieldSets.java
@@ -19,5 +19,7 @@ import com.nawforce.runforce.System.String;
 
 @SuppressWarnings("unused")
 public class SObjectTypeFieldSets {
+    private SObjectTypeFieldSets(){throw new java.lang.UnsupportedOperationException();}
+
     public Map<String, FieldSet> getMap() {throw new java.lang.UnsupportedOperationException();}
 }

--- a/src/main/java/com/nawforce/runforce/Schema/SObjectTypeFieldSets.java
+++ b/src/main/java/com/nawforce/runforce/Schema/SObjectTypeFieldSets.java
@@ -19,7 +19,7 @@ import com.nawforce.runforce.System.String;
 
 @SuppressWarnings("unused")
 public class SObjectTypeFieldSets {
-    private SObjectTypeFieldSets(){throw new java.lang.UnsupportedOperationException();}
+    protected SObjectTypeFieldSets(){throw new java.lang.UnsupportedOperationException();}
 
     public Map<String, FieldSet> getMap() {throw new java.lang.UnsupportedOperationException();}
 }

--- a/src/main/java/com/nawforce/runforce/Schema/SObjectTypeFields.java
+++ b/src/main/java/com/nawforce/runforce/Schema/SObjectTypeFields.java
@@ -19,7 +19,7 @@ import com.nawforce.runforce.System.String;
 
 @SuppressWarnings("unused")
 public class SObjectTypeFields {
-    private SObjectTypeFields(){throw new java.lang.UnsupportedOperationException();}
+    protected SObjectTypeFields(){throw new java.lang.UnsupportedOperationException();}
 
     public Map<String, SObjectField> getMap() {throw new java.lang.UnsupportedOperationException();}
 }

--- a/src/main/java/com/nawforce/runforce/Schema/SObjectTypeFields.java
+++ b/src/main/java/com/nawforce/runforce/Schema/SObjectTypeFields.java
@@ -19,5 +19,7 @@ import com.nawforce.runforce.System.String;
 
 @SuppressWarnings("unused")
 public class SObjectTypeFields {
+    private SObjectTypeFields(){throw new java.lang.UnsupportedOperationException();}
+
     public Map<String, SObjectField> getMap() {throw new java.lang.UnsupportedOperationException();}
 }

--- a/src/main/java/com/nawforce/runforce/System/Blob.java
+++ b/src/main/java/com/nawforce/runforce/System/Blob.java
@@ -16,6 +16,8 @@ package com.nawforce.runforce.System;
 
 @SuppressWarnings("unused")
 public class Blob {
+    private Blob(){throw new java.lang.UnsupportedOperationException();}
+
 	public Integer size() {throw new java.lang.UnsupportedOperationException();}
 	public String toString$() {throw new java.lang.UnsupportedOperationException();}
 

--- a/src/main/java/com/nawforce/runforce/System/Boolean.java
+++ b/src/main/java/com/nawforce/runforce/System/Boolean.java
@@ -16,6 +16,8 @@ package com.nawforce.runforce.System;
 
 @SuppressWarnings("unused")
 public class Boolean {
+    private Boolean(){throw new java.lang.UnsupportedOperationException();}
+
 	public void addError(Exception msg) {throw new java.lang.UnsupportedOperationException();}
 	public void addError(Exception msg, Boolean escape) {throw new java.lang.UnsupportedOperationException();}
 	public void addError(String msg) {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/System/Datetime.java
+++ b/src/main/java/com/nawforce/runforce/System/Datetime.java
@@ -16,6 +16,8 @@ package com.nawforce.runforce.System;
 
 @SuppressWarnings("unused")
 public class Datetime {
+    private Datetime(){throw new java.lang.UnsupportedOperationException();}
+
 	public Datetime addDays(Integer days) {throw new java.lang.UnsupportedOperationException();}
 	public void addError(Exception msg) {throw new java.lang.UnsupportedOperationException();}
 	public void addError(Exception msg, Boolean escape) {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/System/Double.java
+++ b/src/main/java/com/nawforce/runforce/System/Double.java
@@ -16,6 +16,8 @@ package com.nawforce.runforce.System;
 
 @SuppressWarnings("unused")
 public class Double {
+    private Double(){throw new java.lang.UnsupportedOperationException();}
+
 	public void addError(Exception msg) {throw new java.lang.UnsupportedOperationException();}
 	public void addError(Exception msg, Boolean escape) {throw new java.lang.UnsupportedOperationException();}
 	public void addError(String msg) {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/System/Integer.java
+++ b/src/main/java/com/nawforce/runforce/System/Integer.java
@@ -16,6 +16,8 @@ package com.nawforce.runforce.System;
 
 @SuppressWarnings("unused")
 public class Integer {
+    private Integer(){throw new java.lang.UnsupportedOperationException();}
+
 	public void addError(Exception msg) {throw new java.lang.UnsupportedOperationException();}
 	public void addError(Exception msg, Boolean escape) {throw new java.lang.UnsupportedOperationException();}
 	public void addError(String msg) {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/System/List.java
+++ b/src/main/java/com/nawforce/runforce/System/List.java
@@ -20,6 +20,7 @@ public class List<T> implements Iterable<T> {
     public List() {throw new java.lang.UnsupportedOperationException();}
     public List(List<T> listToCopy) {throw new java.lang.UnsupportedOperationException();}
     public List(Set<T> setToCopy) {throw new java.lang.UnsupportedOperationException();}
+    public List(Integer size) {throw new java.lang.UnsupportedOperationException();}
 
     public void add(T listElement) {throw new java.lang.UnsupportedOperationException();}
     public void add(Integer index, T listElement) {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/System/Long.java
+++ b/src/main/java/com/nawforce/runforce/System/Long.java
@@ -16,6 +16,8 @@ package com.nawforce.runforce.System;
 
 @SuppressWarnings("unused")
 public class Long {
+    private Long(){throw new java.lang.UnsupportedOperationException();}
+
 	public void addError(Exception msg) {throw new java.lang.UnsupportedOperationException();}
 	public void addError(Exception msg, Boolean escape) {throw new java.lang.UnsupportedOperationException();}
 	public void addError(String msg) {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/System/QuickAction.java
+++ b/src/main/java/com/nawforce/runforce/System/QuickAction.java
@@ -18,6 +18,8 @@ import com.nawforce.runforce.QuickAction.*;
 
 @SuppressWarnings("unused")
 public class QuickAction {
+    private QuickAction(){throw new java.lang.UnsupportedOperationException();}
+
 	public static List<DescribeAvailableQuickActionResult> describeAvailableQuickActions(String parentType) {throw new java.lang.UnsupportedOperationException();}
 	public static List<DescribeQuickActionResult> describeQuickActions(List<String> actions) {throw new java.lang.UnsupportedOperationException();}
 	public static QuickActionResult performQuickAction(QuickActionRequest performQuickAction) {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/System/Request.java
+++ b/src/main/java/com/nawforce/runforce/System/Request.java
@@ -29,6 +29,8 @@ package com.nawforce.runforce.System;
 
 @SuppressWarnings("unused")
 public class Request {
+    private Request(){throw new java.lang.UnsupportedOperationException();}
+
   public static Request getCurrent() {throw new java.lang.UnsupportedOperationException();}
 
   public Quiddity getQuiddity() {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/System/ResetPasswordResult.java
+++ b/src/main/java/com/nawforce/runforce/System/ResetPasswordResult.java
@@ -18,5 +18,7 @@ package com.nawforce.runforce.System;
 public class ResetPasswordResult {
 	public String password;
 
+    private ResetPasswordResult(){throw new java.lang.UnsupportedOperationException();}
+
 	public String getPassword() {throw new java.lang.UnsupportedOperationException();}
 }

--- a/src/main/java/com/nawforce/runforce/System/SObject.java
+++ b/src/main/java/com/nawforce/runforce/System/SObject.java
@@ -25,6 +25,8 @@ public class SObject {
 	public Id Id;
 	public UserRecordAccess UserRecordAccess;
 
+    private SObject(){throw new java.lang.UnsupportedOperationException();}
+
 	public void addError(Exception exceptionError) {throw new java.lang.UnsupportedOperationException();}
 	public void addError(Exception exceptionError, Boolean escape) {throw new java.lang.UnsupportedOperationException();}
 	public void addError(String msg) {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/System/SObject.java
+++ b/src/main/java/com/nawforce/runforce/System/SObject.java
@@ -25,7 +25,7 @@ public class SObject {
 	public Id Id;
 	public UserRecordAccess UserRecordAccess;
 
-    private SObject(){throw new java.lang.UnsupportedOperationException();}
+    protected SObject(){throw new java.lang.UnsupportedOperationException();}
 
 	public void addError(Exception exceptionError) {throw new java.lang.UnsupportedOperationException();}
 	public void addError(Exception exceptionError, Boolean escape) {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/System/SandboxContext.java
+++ b/src/main/java/com/nawforce/runforce/System/SandboxContext.java
@@ -16,6 +16,8 @@ package com.nawforce.runforce.System;
 
 @SuppressWarnings("unused")
 public class SandboxContext {
+    private SandboxContext(){throw new java.lang.UnsupportedOperationException();}
+
 	public Id organizationId() {throw new java.lang.UnsupportedOperationException();}
 	public Id sandboxId() {throw new java.lang.UnsupportedOperationException();}
 	public String sandboxName() {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/System/String.java
+++ b/src/main/java/com/nawforce/runforce/System/String.java
@@ -16,6 +16,8 @@ package com.nawforce.runforce.System;
 
 @SuppressWarnings("unused")
 public class String {
+    private String(){throw new java.lang.UnsupportedOperationException();}
+
 	public String abbreviate(Integer maxWidth) {throw new java.lang.UnsupportedOperationException();}
 	public String abbreviate(Integer maxWidth, Integer offset) {throw new java.lang.UnsupportedOperationException();}
 	public void addError(Exception msg) {throw new java.lang.UnsupportedOperationException();}

--- a/src/main/java/com/nawforce/runforce/System/WebServiceCalloutFuture.java
+++ b/src/main/java/com/nawforce/runforce/System/WebServiceCalloutFuture.java
@@ -17,8 +17,6 @@ package com.nawforce.runforce.System;
 @SuppressWarnings("unused")
 public class WebServiceCalloutFuture {
 
-	public WebServiceCalloutFuture() {throw new java.lang.UnsupportedOperationException();}
-
-
-
+    private WebServiceCalloutFuture() {throw new java.lang.UnsupportedOperationException();}
+    public static void invoke(Object stub, Object request, Map<String,Object> response, List<String> infoArray) {throw new java.lang.UnsupportedOperationException();}
 }

--- a/src/main/java/com/nawforce/runforce/eventbus/TriggerContext.java
+++ b/src/main/java/com/nawforce/runforce/eventbus/TriggerContext.java
@@ -22,6 +22,8 @@ public class TriggerContext {
 	public String lastError;
 	public Integer retries;
 
+    private TriggerContext(){throw new java.lang.UnsupportedOperationException();}
+
 	public static TriggerContext currentContext() {throw new java.lang.UnsupportedOperationException();}
 
 	public String getResumeCheckpoint() {throw new java.lang.UnsupportedOperationException();}


### PR DESCRIPTION
Adds private constructors for unconstructable types. 
Verified by `Type.forName(...).newInstance()` calls where the error was 'Type cannot be constructed '. There are other types that also throw an error when using Type.forName but they seemed to be inconsistent with docs so not included them.